### PR TITLE
Add sig int handler

### DIFF
--- a/canon.cabal
+++ b/canon.cabal
@@ -53,6 +53,7 @@ library
     , text
     , time
     , transformers-either
+    , unix
     , unordered-containers
     , uuid
   default-language: Haskell2010
@@ -84,6 +85,7 @@ executable canon-exe
     , text
     , time
     , transformers-either
+    , unix
     , unordered-containers
     , uuid
   default-language: Haskell2010
@@ -116,6 +118,7 @@ test-suite canon-test
     , text
     , time
     , transformers-either
+    , unix
     , unordered-containers
     , uuid
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 - http-api-data
 - http-client-tls
 - uuid
+- unix
 - transformers-either
 
 ghc-options:

--- a/src/SessionBuilder.hs
+++ b/src/SessionBuilder.hs
@@ -205,9 +205,8 @@ runCommand = \case
 randomInt :: IO Word8
 randomInt = makeNatual <$> randomIO
   where
-    makeNatual a | a < 0 = (a * (-1)) `mod` 10000
-                 | a == 0 = 1
-                 | otherwise = a `mod` 10000
+    makeNatual a | a == 0 = 1
+                 | otherwise = a
 
 randomUUID :: IO Text
 randomUUID =


### PR DESCRIPTION
On cmd+c or ctrl+c the process gets terminated abruptly giving no report in the end . Add a sigINT handler that catches the signal and makes the stopRef to true prematurely so the Report can be generated with whatever work was done till this time