### PR TITLE
Fix RandomInt function to always generate natural numbers

### DIFF
--- a/src/SessionBuilder.hs
+++ b/src/SessionBuilder.hs
@@ -205,9 +205,8 @@ runCommand = \case
 randomInt :: IO Word8
 randomInt = makeNatual <$> randomIO
   where
-    makeNatual a | a < 0 = (a * (-1)) `mod` 10000
-                 | a == 0 = 1
-                 | otherwise = a `mod` 10000
+    makeNatual a | a == 0 = 1
+                 | otherwise = a
 
 randomUUID :: IO Text
 randomUUID =


### PR DESCRIPTION
Remove mod 10000 from randomInt because it was generating 0 as output